### PR TITLE
open nodePort on host with port 10050/10051

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
       - run:
           name: helm-github-pages
           environment:
-            - GITHUB_PAGES_REPO: evermind/helm-charts
+            - GITHUB_PAGES_REPO: cetic/helm-charts
             - HELM_CHART: zabbix
             - HELM_VERSION: 3.3.4
           command: wget -O - https://gist.githubusercontent.com/alexnuttinck/2e9b8595e9a94ba3b3d00eea690e37ac/raw/9989a66c1de2eb4a8bce7c44ec5fbe1f43459762/publish.sh | sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
       - run:
           name: helm-github-pages
           environment:
-            - GITHUB_PAGES_REPO: cetic/helm-charts
+            - GITHUB_PAGES_REPO: evermind/helm-charts
             - HELM_CHART: zabbix
             - HELM_VERSION: 3.3.4
           command: wget -O - https://gist.githubusercontent.com/alexnuttinck/2e9b8595e9a94ba3b3d00eea690e37ac/raw/9989a66c1de2eb4a8bce7c44ec5fbe1f43459762/publish.sh | sh

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,8 +1,8 @@
 ---
 apiVersion: v2
 name: zabbix
-version: 0.2.2
-appVersion: 5.0.4
+version: 0.3.1
+appVersion: 5.2.0
 description: Zabbix is a mature and effortless enterprise-class open source monitoring solution for network monitoring and application monitoring of millions of metrics.
 keywords:
   - zabbix

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 name: zabbix
-version: 0.2.1
+version: 0.2.2
 appVersion: 5.0.4
 description: Zabbix is a mature and effortless enterprise-class open source monitoring solution for network monitoring and application monitoring of millions of metrics.
 keywords:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Helm Chart For Zabbix.
 
-[![CircleCI](https://circleci.com/gh/cetic/helm-zabbix.svg?style=svg)](https://circleci.com/gh/cetic/helm-zabbix/tree/master) [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) ![version](https://img.shields.io/github/tag/cetic/helm-zabbix.svg?label=release) ![Version: 0.2.1](https://img.shields.io/badge/Version-0.2.1-informational?style=flat-square)
+[![CircleCI](https://circleci.com/gh/cetic/helm-zabbix.svg?style=svg)](https://circleci.com/gh/cetic/helm-zabbix/tree/master) [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) ![version](https://img.shields.io/github/tag/cetic/helm-zabbix.svg?label=release) ![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square)
 
 Zabbix is a mature and effortless enterprise-class open source monitoring solution for network monitoring and application monitoring of millions of metrics.
 
@@ -34,7 +34,7 @@ The server performs the polling and trapping of data, it calculates triggers, se
 
 **Zabbix web** interface is a part of Zabbix software. It is used to manage resources under monitoring and view monitoring statistics.
 
-## Zabbix Proxy
+## Zabbix Proxy 
 
 > **Zabbix proxy** is not functional in this helm chart, yet.
 
@@ -121,7 +121,7 @@ helm delete zabbix -n monitoring
 
 # How to access Zabbix
 
-After deploying the chart in your cluster, you can use the following command to access the zabbix frontend service:
+After deploying the chart in your cluster, you can use the following command to access the zabbix frontend service: 
 
 View informations of ``zabbix`` services.
 
@@ -175,14 +175,14 @@ The following tables lists the configurable parameters of the chart and their de
 | zabbixServer.POSTGRES_DB | string | `"zabbix"` | Name of database |
 | zabbixServer.POSTGRES_PASSWORD | string | `"zabbix_pwd"` | Password of database |
 | zabbixServer.POSTGRES_USER | string | `"zabbix"` | User of database |
+| zabbixServer.hostIP | string | `"0.0.0.0"` | optional set hostIP different from 0.0.0.0 to open port only on this IP |
+| zabbixServer.hostPort | bool | `false` | optional set true open a port direct on node where zabbix server runs  |
 | zabbixServer.image.pullPolicy | string | `"IfNotPresent"` | Pull policy of Docker image |
 | zabbixServer.image.repository | string | `"zabbix/zabbix-server-pgsql"` | Zabbix server Docker image name |
 | zabbixServer.image.tag | string | `"ubuntu-5.0.4"` | Tag of Docker image of Zabbix server |
 | zabbixServer.replicaCount | int | `1` | Number of replicas of ``zabbixServer`` module |
 | zabbixServer.service.port | int | `10051` | Port of service in Kubernetes cluster |
 | zabbixServer.service.type | string | `"ClusterIP"` | Type of service in Kubernetes cluster |
-| zabbixServer.hostPort | bool | `false` | open hostPort on node where Zabbix server deployed |
-| zabbixServer.hostIP | string | `0.0.0.0` | in case of multiple IPs on node restrict hostPort to given IP | 
 | zabbixagent.ZBX_ACTIVE_ALLOW | bool | `true` | This variable is boolean (true or false) and enables or disables feature of active checks |
 | zabbixagent.ZBX_HOSTNAME | string | `"zabbix-agent"` | Zabbix agent hostname Case sensitive hostname |
 | zabbixagent.ZBX_JAVAGATEWAY_ENABLE | bool | `false` | The variable enable communication with Zabbix Java Gateway to collect Java related checks. By default, value is false. |

--- a/README.md
+++ b/README.md
@@ -181,6 +181,8 @@ The following tables lists the configurable parameters of the chart and their de
 | zabbixServer.replicaCount | int | `1` | Number of replicas of ``zabbixServer`` module |
 | zabbixServer.service.port | int | `10051` | Port of service in Kubernetes cluster |
 | zabbixServer.service.type | string | `"ClusterIP"` | Type of service in Kubernetes cluster |
+| zabbixServer.hostPort | bool | `false` | open hostPort on node where Zabbix server deployed |
+| zabbixServer.hostIP | string | `0.0.0.0` | in case of multiple IPs on node restrict hostPort to given IP | 
 | zabbixagent.ZBX_ACTIVE_ALLOW | bool | `true` | This variable is boolean (true or false) and enables or disables feature of active checks |
 | zabbixagent.ZBX_HOSTNAME | string | `"zabbix-agent"` | Zabbix agent hostname Case sensitive hostname |
 | zabbixagent.ZBX_JAVAGATEWAY_ENABLE | bool | `false` | The variable enable communication with Zabbix Java Gateway to collect Java related checks. By default, value is false. |

--- a/templates/StatefulSet.yaml
+++ b/templates/StatefulSet.yaml
@@ -29,8 +29,16 @@ spec:
           ports:
             - containerPort: 10051
               name: zabbix-trapper
+              hostPort: 10051
+              {{- if ne "0.0.0.0" .Values.zabbixServer.hostIP }}
+              hostIP: {{ .Values.zabbixServer.hostIP }}
+              {{- end}}    
             - containerPort: 10052
               name: zabbix-jmx
+              hostPort: 10052              
+              {{- if ne "0.0.0.0" .Values.zabbixServer.hostIP }}
+              hostIP: {{ .Values.zabbixServer.hostIP }}
+              {{- end}}    
           env:
             - name: DB_SERVER_HOST
               value: {{ .Values.zabbixServer.DB_SERVER_HOST }}

--- a/templates/StatefulSet.yaml
+++ b/templates/StatefulSet.yaml
@@ -29,13 +29,17 @@ spec:
           ports:
             - containerPort: 10051
               name: zabbix-trapper
+              {{- if (default false .Values.zabbixServer.hostPort) }}
               hostPort: 10051
+              {{- end }}
               {{- if ne "0.0.0.0" .Values.zabbixServer.hostIP }}
               hostIP: {{ .Values.zabbixServer.hostIP }}
               {{- end}}    
             - containerPort: 10052
               name: zabbix-jmx
+              {{- if (default false .Values.zabbixServer.hostPort) }}
               hostPort: 10052              
+              {{- end }}
               {{- if ne "0.0.0.0" .Values.zabbixServer.hostIP }}
               hostIP: {{ .Values.zabbixServer.hostIP }}
               {{- end}}    

--- a/values.yaml
+++ b/values.yaml
@@ -6,9 +6,9 @@
 zabbixServer:
   # zabbixServer.replicaCount -- Number of replicas of ``zabbixServer`` module
   replicaCount: 1
-  # optional set true open a port direct on node where zabbix server runs 
+  # zabbixServer.hostPort -- optional set true open a port direct on node where zabbix server runs 
   hostPort: false
-  # optional set hostIP different from 0.0.0.0 to open port only on this IP
+  # zabbixServer.hostIP -- optional set hostIP different from 0.0.0.0 to open port only on this IP
   hostIP: 0.0.0.0
   image:
     # zabbixServer.image.repository -- Zabbix server Docker image name

--- a/values.yaml
+++ b/values.yaml
@@ -6,6 +6,8 @@
 zabbixServer:
   # zabbixServer.replicaCount -- Number of replicas of ``zabbixServer`` module
   replicaCount: 1
+  # optional set hostIP different from 0.0.0.0 open a port direct on node where zabbix server runs
+  hostIP: 0.0.0.0
   image:
     # zabbixServer.image.repository -- Zabbix server Docker image name
     repository: zabbix/zabbix-server-pgsql

--- a/values.yaml
+++ b/values.yaml
@@ -6,7 +6,9 @@
 zabbixServer:
   # zabbixServer.replicaCount -- Number of replicas of ``zabbixServer`` module
   replicaCount: 1
-  # optional set hostIP different from 0.0.0.0 open a port direct on node where zabbix server runs
+  # optional set true open a port direct on node where zabbix server runs 
+  hostPort: false
+  # optional set hostIP different from 0.0.0.0 to open port only on this IP
   hostIP: 0.0.0.0
   image:
     # zabbixServer.image.repository -- Zabbix server Docker image name


### PR DESCRIPTION
<!--
Thank you for contributing to this repository. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
the review guidelines form the Helm repository:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
NodePort for services open Port different from original Zabbix ports.

#### Which issue this PR fixes
Open ports on node via NodePort open Ports >32000 (if you using rancher kubernetes). To use the original Zabbix ports 10051 and 10052 the solution is to open this port directly on the host where it is deployed.


#### Special notes for your reviewer:


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
