### PR TITLE
Allow passing imagePullSecrets to deployment and statefulset

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 name: zabbix
-version: 0.3.0
+version: 0.3.1
 appVersion: 5.2.0
 description: Zabbix is a mature and effortless enterprise-class open source monitoring solution for network monitoring and application monitoring of millions of metrics.
 keywords:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Helm Chart For Zabbix.
 
-[![CircleCI](https://circleci.com/gh/cetic/helm-zabbix.svg?style=svg)](https://circleci.com/gh/cetic/helm-zabbix/tree/master) [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) ![version](https://img.shields.io/github/tag/cetic/helm-zabbix.svg?label=release) ![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square)
+[![CircleCI](https://circleci.com/gh/cetic/helm-zabbix.svg?style=svg)](https://circleci.com/gh/cetic/helm-zabbix/tree/master) [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) ![version](https://img.shields.io/github/tag/cetic/helm-zabbix.svg?label=release) ![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square)
 
 Zabbix is a mature and effortless enterprise-class open source monitoring solution for network monitoring and application monitoring of millions of metrics.
 
@@ -177,6 +177,7 @@ The following tables lists the configurable parameters of the chart and their de
 | zabbixServer.POSTGRES_PASSWORD | string | `"zabbix_pwd"` | Password of database |
 | zabbixServer.POSTGRES_USER | string | `"zabbix"` | User of database |
 | zabbixServer.image.pullPolicy | string | `"IfNotPresent"` | Pull policy of Docker image |
+| zabbixServer.image.pullSecrets | list | `[]` | List of dockerconfig secrets names to use when pulling images |
 | zabbixServer.image.repository | string | `"zabbix/zabbix-server-pgsql"` | Zabbix server Docker image name |
 | zabbixServer.image.tag | string | `"ubuntu-5.2.0"` | Tag of Docker image of Zabbix server |
 | zabbixServer.replicaCount | int | `1` | Number of replicas of ``zabbixServer`` module |
@@ -192,6 +193,7 @@ The following tables lists the configurable parameters of the chart and their de
 | zabbixagent.ZBX_VMWARECACHESIZE | string | `"128M"` | Cache size |
 | zabbixagent.enabled | bool | `true` | Enables use of Zabbix agent |
 | zabbixagent.image.pullPolicy | string | `"IfNotPresent"` | Pull policy of Docker image |
+| zabbixagent.image.pullSecrets | list | `[]` | List of dockerconfig secrets names to use when pulling images |
 | zabbixagent.image.repository | string | `"zabbix/zabbix-agent"` | Zabbix agent Docker image name |
 | zabbixagent.image.tag | string | `"ubuntu-5.2.0"` | Tag of Docker image of Zabbix agent |
 | zabbixagent.service.port | int | `10050` | Port to expose service |
@@ -210,6 +212,7 @@ The following tables lists the configurable parameters of the chart and their de
 | zabbixproxy.ZBX_VMWARECACHESIZE | string | `"128M"` | Cache size |
 | zabbixproxy.enabled | bool | `false` | Enables use of **Zabbix proxy** |
 | zabbixproxy.image.pullPolicy | string | `"IfNotPresent"` | Pull policy of Docker image |
+| zabbixproxy.image.pullSecrets | list | `[]` | List of dockerconfig secrets names to use when pulling images |
 | zabbixproxy.image.repository | string | `"zabbix/zabbix-proxy-mysql"` | Zabbix proxy Docker image name |
 | zabbixproxy.image.tag | string | `"ubuntu-5.2.0"` | Tag of Docker image of Zabbix proxy |
 | zabbixproxy.service.port | int | `10051` | Port to expose service |
@@ -224,6 +227,7 @@ The following tables lists the configurable parameters of the chart and their de
 | zabbixweb.ZBX_SERVER_PORT | int | `10051` | Zabbix server port |
 | zabbixweb.enabled | bool | `true` | Enables use of Zabbix web |
 | zabbixweb.image.pullPolicy | string | `"IfNotPresent"` | Pull policy of Docker image |
+| zabbixweb.image.pullSecrets | list | `[]` | List of dockerconfig secrets names to use when pulling images |
 | zabbixweb.image.repository | string | `"zabbix/zabbix-web-apache-pgsql"` | Zabbix web Docker image name |
 | zabbixweb.image.tag | string | `"ubuntu-5.2.0"` | Tag of Docker image of Zabbix web |
 | zabbixweb.service.port | int | `80` | Port to expose service |

--- a/templates/StatefulSet.yaml
+++ b/templates/StatefulSet.yaml
@@ -114,3 +114,15 @@ spec:
               containerPort: 10051
               protocol: TCP
         {{- end }}
+      imagePullSecrets:
+      {{- range .Values.zabbixServer.image.pullSecrets }}
+        - name: {{ . | quote }}
+      {{- end }}
+      {{- range .Values.zabbixagent.image.pullSecrets }}
+        - name: {{ . | quote }}
+      {{- end }}
+      {{- if .Values.zabbixproxy.enabled }}
+      {{- range .Values.zabbixproxy.image.pullSecrets }}
+        - name: {{ . | quote }}
+      {{- end }}
+      {{- end }}

--- a/templates/Web-deplyment.yaml
+++ b/templates/Web-deplyment.yaml
@@ -70,3 +70,7 @@ spec:
           successThreshold: {{ .Values.readinessProbe.successThreshold }}
           failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
         {{- end }}
+      imagePullSecrets:
+      {{- range .Values.zabbixweb.image.pullSecrets }}
+        - name: {{ . | quote }}
+      {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -13,6 +13,8 @@ zabbixServer:
     tag: ubuntu-5.2.0
     # -- Pull policy of Docker image
     pullPolicy: IfNotPresent
+    # -- List of dockerconfig secrets names to use when pulling images
+    pullSecrets: []
   # -- Address of database host
   DB_SERVER_HOST: "zabbix-postgresql"
   # -- User of database
@@ -51,6 +53,8 @@ zabbixproxy:
     tag: ubuntu-5.2.0
     # -- Pull policy of Docker image
     pullPolicy: IfNotPresent
+    #  -- List of dockerconfig secrets names to use when pulling images
+    pullSecrets: []
   # -- The variable allows to switch Zabbix proxy mode. Bu default, value is 0 - active proxy. Allowed values are 0 and 1.
   ZBX_PROXYMODE: 0
   # -- Zabbix proxy hostname
@@ -103,6 +107,8 @@ zabbixagent:
     tag: ubuntu-5.2.0
     # -- Pull policy of Docker image
     pullPolicy: IfNotPresent
+    # -- List of dockerconfig secrets names to use when pulling images
+    pullSecrets: []
   # -- Zabbix agent hostname
   # Case sensitive hostname
   ZBX_HOSTNAME: zabbix-agent
@@ -148,6 +154,8 @@ zabbixweb:
     tag: ubuntu-5.2.0
     # -- Pull policy of Docker image
     pullPolicy: IfNotPresent
+    # zabbixweb.image.pullSecrets -- List of dockerconfig secrets names to use when pulling images
+    pullSecrets: []
   # -- Zabbix server host
   ZBX_SERVER_HOST: zabbix-server
   # -- Zabbix server port


### PR DESCRIPTION
#### What this PR does / why we need it:

Prior to this commit users were able to pass custom images to the chart,
but usage of this feature was limited by using public registries, which
do not require authorization only.

This change adds possibility to pass imagePullSecrets name, thus
allowing usage of the chart with private registries. Users can define
one of

- zabbixServer.image.pullSecrets
- zabbixagent.image.pullSecrets
- zabbixproxy.image.pullSecrets
- zabbixweb.image.pullSecrets

to set corresponding imagePullSecrets for different components.

Intended usage is the following:

```console
$ cat values.yaml
...
zabbixServer:
  image:
    repository: registry.example.com/zabbix-custom/server
    pullSecrets:
      - server-registry-secret
...
zabbixweb:
  image:
    repository: registry.example.com/zabbix-custom/web
    pullSecrets:
      - web-registry-secret
```

Please note, that the secret in the cluster should be created prior to
chart deployment manually. The command from
https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#registry-secret-existing-credentials
can be used in order to create corresponding secret in kubernetes
cluster.


#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
