### PR TITLE
adding zabbixServer.DB_SERVER_PORT

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 name: zabbix
-version: 0.2.1
+version: 0.2.2
 appVersion: 5.0.4
 description: Zabbix is a mature and effortless enterprise-class open source monitoring solution for network monitoring and application monitoring of millions of metrics.
 keywords:

--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ The following tables lists the configurable parameters of the chart and their de
 | readinessProbe.timeoutSeconds | int | `5` | Number of seconds after which the probe times out |
 | tolerations | list | `[]` | Tolerations configurations |
 | zabbixServer.DB_SERVER_HOST | string | `"zabbix-postgresql"` | Address of database host |
+| zabbixServer.DB_SERVER_PORT | string | `5432` | Address of database host |
 | zabbixServer.POSTGRES_DB | string | `"zabbix"` | Name of database |
 | zabbixServer.POSTGRES_PASSWORD | string | `"zabbix_pwd"` | Password of database |
 | zabbixServer.POSTGRES_USER | string | `"zabbix"` | User of database |

--- a/templates/StatefulSet.yaml
+++ b/templates/StatefulSet.yaml
@@ -34,6 +34,8 @@ spec:
           env:
             - name: DB_SERVER_HOST
               value: {{ .Values.zabbixServer.DB_SERVER_HOST }}
+            - name: DB_SERVER_PORT
+              value: {{ .Values.zabbixServer.DB_SERVER_PORT | quote }}
             - name: POSTGRES_USER
               value: {{ .Values.zabbixServer.POSTGRES_USER }}
             - name: POSTGRES_PASSWORD


### PR DESCRIPTION
#### What this PR does / why we need it:

adds the postgresql port option to use a db service, like digital ocean.  

#### Special notes for your reviewer:
tested and works, wonder if there is a reason for the 2 sets of db credentials if they need to be the same?

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
