### PR TITLE
Honor nodeSelector, tolerations, and affinity values from values.yaml

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 name: zabbix
-version: 0.4.3
+version: 0.4.4
 appVersion: 5.4.5
 description: Zabbix is a mature and effortless enterprise-class open source monitoring solution for network monitoring and application monitoring of millions of metrics.
 keywords:

--- a/templates/StatefulSet-zabbix-proxy.yaml
+++ b/templates/StatefulSet-zabbix-proxy.yaml
@@ -31,7 +31,18 @@ spec:
 {{- toYaml .Values.tolerations | nindent 8 }}
       affinity:
 {{- toYaml .Values.affinity | nindent 8 }}
-
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
           {{- if .Values.zabbixagent.enabled }}
         - name: zabbix-agent

--- a/templates/StatefulSet-zabbix-proxy.yaml
+++ b/templates/StatefulSet-zabbix-proxy.yaml
@@ -25,12 +25,6 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}-zabbix-proxy
         app.kubernetes.io/managed-by: {{ .Release.Service }}-zabbix-proxy
     spec:
-      nodeSelector:
-{{- toYaml .Values.nodeSelector | nindent 8 }}
-      tolerations:
-{{- toYaml .Values.tolerations | nindent 8 }}
-      affinity:
-{{- toYaml .Values.affinity | nindent 8 }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/templates/StatefulSet-zabbix-proxy.yaml
+++ b/templates/StatefulSet-zabbix-proxy.yaml
@@ -25,6 +25,13 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}-zabbix-proxy
         app.kubernetes.io/managed-by: {{ .Release.Service }}-zabbix-proxy
     spec:
+      nodeSelector:
+{{- toYaml .Values.nodeSelector | nindent 8 }}
+      tolerations:
+{{- toYaml .Values.tolerations | nindent 8 }}
+      affinity:
+{{- toYaml .Values.affinity | nindent 8 }}
+
       containers:
           {{- if .Values.zabbixagent.enabled }}
         - name: zabbix-agent

--- a/templates/StatefulSet-zabbix-server.yaml
+++ b/templates/StatefulSet-zabbix-server.yaml
@@ -30,7 +30,18 @@ spec:
 {{- toYaml .Values.tolerations | nindent 8 }}
       affinity:
 {{- toYaml .Values.affinity | nindent 8 }}
-
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: zabbix-server
           resources:

--- a/templates/StatefulSet-zabbix-server.yaml
+++ b/templates/StatefulSet-zabbix-server.yaml
@@ -24,6 +24,13 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}-zabbix-server
         app.kubernetes.io/managed-by: {{ .Release.Service }}-zabbix-server
     spec:
+      nodeSelector:
+{{- toYaml .Values.nodeSelector | nindent 8 }}
+      tolerations:
+{{- toYaml .Values.tolerations | nindent 8 }}
+      affinity:
+{{- toYaml .Values.affinity | nindent 8 }}
+
       containers:
         - name: zabbix-server
           resources:

--- a/templates/StatefulSet-zabbix-server.yaml
+++ b/templates/StatefulSet-zabbix-server.yaml
@@ -24,12 +24,6 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}-zabbix-server
         app.kubernetes.io/managed-by: {{ .Release.Service }}-zabbix-server
     spec:
-      nodeSelector:
-{{- toYaml .Values.nodeSelector | nindent 8 }}
-      tolerations:
-{{- toYaml .Values.tolerations | nindent 8 }}
-      affinity:
-{{- toYaml .Values.affinity | nindent 8 }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/templates/Web-deployment.yaml
+++ b/templates/Web-deployment.yaml
@@ -23,12 +23,6 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}-zabbix-web
         app.kubernetes.io/managed-by: {{ .Release.Service }}-zabbix-web
     spec:
-      nodeSelector:
-{{- toYaml .Values.nodeSelector | nindent 8 }}
-      tolerations:
-{{- toYaml .Values.tolerations | nindent 8 }}
-      affinity:
-{{- toYaml .Values.affinity | nindent 8 }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/templates/Web-deployment.yaml
+++ b/templates/Web-deployment.yaml
@@ -23,6 +23,13 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}-zabbix-web
         app.kubernetes.io/managed-by: {{ .Release.Service }}-zabbix-web
     spec:
+      nodeSelector:
+{{- toYaml .Values.nodeSelector | nindent 8 }}
+      tolerations:
+{{- toYaml .Values.tolerations | nindent 8 }}
+      affinity:
+{{- toYaml .Values.affinity | nindent 8 }}
+
       containers:
       - name: zabbix-web
         resources:

--- a/templates/Web-deployment.yaml
+++ b/templates/Web-deployment.yaml
@@ -29,7 +29,18 @@ spec:
 {{- toYaml .Values.tolerations | nindent 8 }}
       affinity:
 {{- toYaml .Values.affinity | nindent 8 }}
-
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: zabbix-web
         resources:


### PR DESCRIPTION
#### What this PR does / why we need it:

The `nodeSelector`, `tolerations`, and `affinity` values in the `values.yaml` file were not being implemented in the templates. This PR resolves this.

#### Special notes for your reviewer:

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
