### PR TITLE
Add optional annotations for zabbix-server service

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 name: zabbix
-version: 1.0.1
+version: 1.1.1
 appVersion: 6.0.0
 description: Zabbix is a mature and effortless enterprise-class open source monitoring solution for network monitoring and application monitoring of millions of metrics.
 keywords:

--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ The following tables lists the configurable parameters of the chart and their de
 | zabbixserver.image.tag | string | `"ubuntu-6.0.0"` | Tag of Docker image of Zabbix server |
 | zabbixserver.replicaCount | int | `1` | Number of replicas of ``zabbixserver`` module |
 | zabbixserver.resources | object | `{}` |  |
+| zabbixserver.service.annotations | object | `{}` | Annotations for the zabbix-server service |
 | zabbixserver.service.clusterIP | string | `nil` | Cluster IP for Zabbix server |
 | zabbixserver.service.nodePort | int | `31051` | NodePort of service on each node |
 | zabbixserver.service.port | int | `10051` | Port of service in Kubernetes cluster |

--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ The following tables lists the configurable parameters of the chart and their de
 | zabbixagent.image.repository | string | `"zabbix/zabbix-agent"` | Zabbix agent Docker image name. Can use zabbix/zabbix-agent or zabbix/zabbix-agent2 |
 | zabbixagent.image.tag | string | `"ubuntu-6.0.0"` | Tag of Docker image of Zabbix agent |
 | zabbixagent.resources | object | `{}` |  |
+| zabbixagent.service.annotations | object | `{}` | Annotations for the zabbix-agent service |
 | zabbixagent.service.clusterIP | string | `nil` | Cluster IP for Zabbix agent |
 | zabbixagent.service.port | int | `10050` | Port to expose service |
 | zabbixagent.service.type | string | `"ClusterIP"` | Type of service for Zabbix agent |
@@ -218,6 +219,7 @@ The following tables lists the configurable parameters of the chart and their de
 | zabbixproxy.image.tag | string | `"ubuntu-6.0.0"` | Tag of Docker image of Zabbix proxy |
 | zabbixproxy.replicaCount | int | `1` | Number of replicas of ``zabbixproxy`` module |
 | zabbixproxy.resources | object | `{}` |  |
+| zabbixproxy.service.annotations | object | `{}` | Annotations for the zabbix-proxy service |
 | zabbixproxy.service.clusterIP | string | `nil` | Cluster IP for Zabbix proxy |
 | zabbixproxy.service.port | int | `10051` | Port to expose service |
 | zabbixproxy.service.type | string | `"ClusterIP"` | Type of service for Zabbix proxy |
@@ -255,6 +257,7 @@ The following tables lists the configurable parameters of the chart and their de
 | zabbixweb.image.repository | string | `"zabbix/zabbix-web-apache-pgsql"` | Zabbix web Docker image name |
 | zabbixweb.image.tag | string | `"ubuntu-6.0.0"` | Tag of Docker image of Zabbix web |
 | zabbixweb.resources | object | `{}` |  |
+| zabbixweb.service.annotations | object | `{}` | Annotations for the zabbix-web service |
 | zabbixweb.service.clusterIP | string | `nil` | Cluster IP for Zabbix web |
 | zabbixweb.service.port | int | `80` | Port to expose service |
 | zabbixweb.service.type | string | `"NodePort"` | Type of service for Zabbix web |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Helm Chart For Zabbix.
 
-[![CircleCI](https://circleci.com/gh/cetic/helm-zabbix.svg?style=svg)](https://circleci.com/gh/cetic/helm-zabbix/tree/master) [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) ![version](https://img.shields.io/github/tag/cetic/helm-zabbix.svg?label=release) ![Version: 1.0.1](https://img.shields.io/badge/Version-1.0.1-informational?style=flat-square)
+[![CircleCI](https://circleci.com/gh/cetic/helm-zabbix.svg?style=svg)](https://circleci.com/gh/cetic/helm-zabbix/tree/master) [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) ![version](https://img.shields.io/github/tag/cetic/helm-zabbix.svg?label=release) ![Version: 1.1.1](https://img.shields.io/badge/Version-1.1.1-informational?style=flat-square)
 
 Zabbix is a mature and effortless enterprise-class open source monitoring solution for network monitoring and application monitoring of millions of metrics.
 

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -10,6 +10,12 @@ metadata:
     helm.sh/chart: {{ include "zabbix.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}-zabbix-server
     app.kubernetes.io/managed-by: {{ .Release.Service }}-zabbix-server
+  {{- if .Values.zabbixserver.service.annotations }}
+  annotations:
+    {{- range $key,$value := .Values.zabbixserver.service.annotations }}
+    {{ $key }}: {{ $value }}
+    {{- end }}
+  {{- end }}
 spec:
   type: {{ .Values.zabbixserver.service.type }}
   {{- if .Values.zabbixserver.service.clusterIP }}

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -50,6 +50,12 @@ metadata:
     helm.sh/chart: {{ include "zabbix.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}-zabbix-agent
     app.kubernetes.io/managed-by: {{ .Release.Service }}-zabbix-agent
+  {{- if .Values.zabbixagent.service.annotations }}
+  annotations:
+    {{- range $key,$value := .Values.zabbixagent.service.annotations }}
+    {{ $key }}: {{ $value }}
+    {{- end }}
+  {{- end }}
 spec:
   type: {{ .Values.zabbixagent.service.type }}
   {{- if .Values.zabbixagent.service.clusterIP }}
@@ -77,6 +83,12 @@ metadata:
     helm.sh/chart: {{ include "zabbix.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}-zabbix-web
     app.kubernetes.io/managed-by: {{ .Release.Service }}-zabbix-web
+  {{- if .Values.zabbixweb.service.annotations }}
+  annotations:
+    {{- range $key,$value := .Values.zabbixweb.service.annotations }}
+    {{ $key }}: {{ $value }}
+    {{- end }}
+  {{- end }}
 spec:
   type: {{ .Values.zabbixweb.service.type }}
   {{- if .Values.zabbixweb.service.clusterIP }}
@@ -104,6 +116,12 @@ metadata:
     helm.sh/chart: {{ include "zabbix.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}-zabbix-proxy
     app.kubernetes.io/managed-by: {{ .Release.Service }}-zabbix-proxy
+  {{- if .Values.zabbixproxy.service.annotations }}
+  annotations:
+    {{- range $key,$value := .Values.zabbixproxy.service.annotations }}
+    {{ $key }}: {{ $value }}
+    {{- end }}
+  {{- end }}
 spec:
   type: {{ .Values.zabbixproxy.service.type }}
   {{- if .Values.zabbixproxy.service.clusterIP }}

--- a/values.yaml
+++ b/values.yaml
@@ -41,6 +41,9 @@ zabbixserver:
     port: 10051
     # -- NodePort of service on each node
     nodePort: 31051
+    # -- Annotations for the zabbix-server service
+    annotations: {}
+    # metallb.universe.tf/address-pool: production-public-ips
   # -- Extra environment variables. A list of additional environment variables. See example: https://github.com/cetic/helm-zabbix/blob/master/docs/example/kind/values.yaml
   extraEnv: {}
 

--- a/values.yaml
+++ b/values.yaml
@@ -105,6 +105,9 @@ zabbixproxy:
     clusterIP: 
     # -- Port to expose service
     port: 10051
+    # -- Annotations for the zabbix-proxy service
+    annotations: {}
+    # metallb.universe.tf/address-pool: production-public-ips
   # -- Extra environment variables. A list of additional environment variables. See example: https://github.com/cetic/helm-zabbix/blob/master/docs/example/kind/values.yaml
   extraEnv: {}
 
@@ -152,6 +155,9 @@ zabbixagent:
     clusterIP: 
     # -- Port to expose service
     port: 10050
+    # -- Annotations for the zabbix-agent service
+    annotations: {}
+    # metallb.universe.tf/address-pool: production-public-ips
   # -- Extra environment variables. A list of additional environment variables. See example: https://github.com/cetic/helm-zabbix/blob/master/docs/example/kind/values.yaml
   extraEnv: {}
 
@@ -190,6 +196,9 @@ zabbixweb:
     clusterIP: 
     # -- Port to expose service
     port: 80
+    # -- Annotations for the zabbix-web service
+    annotations: {}
+    # metallb.universe.tf/address-pool: production-public-ips
   # -- Extra environment variables. A list of additional environment variables. See example: https://github.com/cetic/helm-zabbix/blob/master/docs/example/kind/values.yaml
   extraEnv: {}
 


### PR DESCRIPTION
#### What this PR does / why we need it:
Add optional annotations for zabbix-service. Can be used for requesting a specific ip-pool from metallb. 
#### Which issue this PR fixes
* none, new feature

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Variables are documented in the README.md
